### PR TITLE
feat: add new ticket entry for "Ready or Not 2: Here I Come"

### DIFF
--- a/src/content/tickets/ready-or-not.md
+++ b/src/content/tickets/ready-or-not.md
@@ -1,0 +1,7 @@
+---
+title: "Ready or Not 2: Here I Come"
+date: "2026-03-29"
+price: "12.00"
+theater: "Marquette Cinemas"
+rating: "R"
+---


### PR DESCRIPTION
This pull request adds a new ticket entry for the film "Ready or Not 2: Here I Come" at Marquette Cinemas.

- Content Update:
  * Added a new Markdown file `ready-or-not.md` with details for the movie "Ready or Not 2: Here I Come," including title, date, price, theater, and rating.