### PR TITLE
fix: adjust layout for RatingsChart and TheatersChart components

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -122,7 +122,7 @@ const internationalCount = tickets.filter((t) => t.data.international).length;
       </p>
     </div>
     <MoviesPerYearChart tickets={tickets} />
-    <RatingsChart tickets={tickets} />
     <TheatersChart tickets={tickets} />
+    <RatingsChart tickets={tickets} />
   </div>
 </Section>

--- a/src/components/RatingsChart.astro
+++ b/src/components/RatingsChart.astro
@@ -35,7 +35,7 @@ const data = Object.entries(ratingCounts)
   });
 ---
 
-<div class="flex flex-col gap-2 py-4 max-lg:border-b lg:border-r">
+<div class="flex flex-col gap-2 py-4 lg:pl-4">
   <h2 class="text-xl md:text-2xl">Rating Breakdown</h2>
   <figure
     id="ratings-chart"

--- a/src/components/TheatersChart.astro
+++ b/src/components/TheatersChart.astro
@@ -22,7 +22,7 @@ const data = Object.entries(theaterCounts)
   .sort((a, b) => b.count - a.count);
 ---
 
-<div class="flex flex-col gap-2 py-4 lg:pl-4 lg:flex-1">
+<div class="flex flex-col gap-2 py-4 lg:flex-1 max-lg:border-b lg:border-r">
   <h2 class="text-xl md:text-2xl">Theater Breakdown</h2>
   <figure
     id="theaters-chart"


### PR DESCRIPTION
This pull request makes minor adjustments to the layout and ordering of components in the `About.astro`, `RatingsChart.astro`, and `TheatersChart.astro` files to improve the visual structure and consistency of the charts section.

Layout and ordering improvements:

* Moved the `RatingsChart` component to appear after the `TheatersChart` in `About.astro` to adjust the order of displayed charts.
* Updated the `RatingsChart.astro` container to remove the border on small screens and add left padding on large screens for better alignment.
* Modified the `TheatersChart.astro` container to add a right border on large screens and a bottom border on small screens, improving visual separation between charts.