### PR TITLE
Fix search initialization and ensure ticketsData is available before processing

### DIFF
--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -9,7 +9,7 @@ const allTickets = await getCollection("tickets");
 
 // Sort tickets by date (newest first) for initial display
 const sortedTickets = allTickets.sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime()
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
 
 // Prepare ticket data for client-side search
@@ -149,6 +149,7 @@ const ticketsData = sortedTickets.map((ticket) => ({
 
   function initializeSearch() {
     const ticketsData = window.ticketsData;
+    if (!ticketsData) return;
     const searchInput = document.getElementById("searchInput");
     const resultsContainer = document.getElementById("resultsContainer");
     const resultsCount = document.getElementById("resultsCount");
@@ -212,7 +213,7 @@ const ticketsData = sortedTickets.map((ticket) => ({
   initializeSearch();
 
   // Re-initialize after view transitions
-  document.addEventListener("astro:after-swap", initializeSearch);
+  document.addEventListener("astro:page-load", initializeSearch);
 </script>
 
 <style>


### PR DESCRIPTION
This pull request makes several small improvements to the `src/pages/search.astro` file, focusing on robustness and event handling in the ticket search functionality.

Improvements to search initialization:

* Added a guard clause to the `initializeSearch` function to prevent errors if `window.ticketsData` is not defined.

Event handling updates:

* Changed the event listener from `astro:after-swap` to `astro:page-load` to ensure that the search initialization runs at the appropriate time after navigation.

Minor code style update:

* Added a trailing comma to the ticket sorting function for consistency.